### PR TITLE
Fix symbol issues on Linux.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ else
 CC = /usr/bin/gcc
 CPLUS = /usr/bin/g++
 CLINK = /usr/bin/gcc
-CPP_LIB = "libgcc_s.so.1"
+CPP_LIB = "-lstdc++ libgcc_s.so.1"
 endif
 
 # put any compiler flags you want passed here
@@ -74,7 +74,7 @@ DEFINES += -DCOMPILER_GCC -DPOSIX -DVPROF_LEVEL=1 -DSWDS -D_finite=finite -Dstri
 UNDEF = -Usprintf -Ustrncpy -UPROTECTED_THINGS_ENABLE
 
 BASE_CFLAGS = -fno-strict-aliasing -Wall -Werror -Wno-conversion -Wno-overloaded-virtual -Wno-non-virtual-dtor -Wno-invalid-offsetof \
-	      -Wno-unused
+	      -Wno-unused -std=c++11
 SHLIBCFLAGS = -fPIC
 
 # Flags passed to the c compiler

--- a/Makefile.plugin
+++ b/Makefile.plugin
@@ -10,7 +10,7 @@ PLUGIN_OBJ_DIR = $(BUILD_OBJ_DIR)/$(NAME)_$(ARCH)
 TIER0_OBJ_DIR = $(PLUGIN_OBJ_DIR)/tier0
 
 INCLUDEDIRS = -I$(PUBLIC_SRC_DIR) -I$(TIER0_PUBLIC_SRC_DIR) -I$(TIER1_PUBLIC_SRC_DIR)
-LDFLAGS_PLG = -lm -ldl $(LIB_DIR)/libtier0.so $(LIB_DIR)/libvstdlib.so $(LIB_DIR)/mathlib_$(ARCH).a $(LIB_DIR)/tier1_$(ARCH).a
+LDFLAGS_PLG = -lm -ldl -L$(LIB_DIR) -ltier0 -lvstdlib $(LIB_DIR)/mathlib_$(ARCH).a $(LIB_DIR)/tier1_$(ARCH).a $(LIB_DIR)/interfaces_$(ARCH).a
 
 DO_CC = $(CPLUS) $(INCLUDEDIRS) -DARCH=$(ARCH)
 


### PR DESCRIPTION
Fixes #20.

Adjustments

* Link to `libtier0.so` and `libvstdlib.so` without the hl2sdk path prefix baked into the binary.
* Link `interfaces_i486.a` which contains the `g_pCVar` symbol definition.
* Use `-std=c++11` to explicitly enable C++11 mode (though most modern compilers do this by default anyway).
* Link against `libstdc++` - needed for C++ features.